### PR TITLE
Updates for Haven compatibility

### DIFF
--- a/src/guarneri/instrument.py
+++ b/src/guarneri/instrument.py
@@ -63,7 +63,12 @@ class Instrument:
 
     devices: Registry
 
-    def __init__(self, device_classes: Mapping, registry: Registry | None = None, ignored_classes: Sequence[str] | None = None):
+    def __init__(
+        self,
+        device_classes: Mapping,
+        registry: Registry | None = None,
+        ignored_classes: Sequence[str] | None = None,
+    ):
         self.unconnected_devices = []
         if registry is None:
             registry = Registry(auto_register=False, use_typhos=False)
@@ -173,7 +178,7 @@ class Instrument:
         # Create devices
         devices = []
         for defn in defns:
-            if defn['device_class'] in self.ignored_classes:
+            if defn["device_class"] in self.ignored_classes:
                 continue
             # Check if we know how to make the device
             try:

--- a/src/guarneri/tests/test_instrument.py
+++ b/src/guarneri/tests/test_instrument.py
@@ -104,6 +104,16 @@ def test_parse_config(cfg_file, instrument):
     assert dfn["device_class"] == "async_device"
 
 
+def test_make_unknown_class(instrument):
+    """Check that unresolvable device classes only raise a warning."""
+    instrument.device_classes = {}
+    cfg = instrument.parse_config(toml_file)
+    print(cfg)
+    assert len(cfg) > 0
+    dfn = cfg[0]
+    assert dfn["device_class"] == "async_device"
+
+
 def test_make_async_devices(instrument, monkeypatch):
     devices = instrument.make_devices(
         [
@@ -142,6 +152,24 @@ def test_make_threaded_devices(instrument, monkeypatch):
     )
     assert len(devices) == 1
     assert devices[0].name == "I0"
+
+
+def test_make_unknown_class(instrument):
+    """Check that unresolvable device classes only raise a warning."""
+    instrument.device_classes = {}
+    defns = [
+        {
+            "device_class": "tardis",
+            "kwargs": {
+                "name": "the tardis",
+            },
+        }
+    ]
+    with pytest.warns() as warned:
+        devices = instrument.make_devices(defns=defns, fake=True)
+    assert len(warned) == 1
+    assert "tardis" in str(warned[0].message)
+    assert len(devices) == 0
 
 
 async def test_connect(instrument):

--- a/src/guarneri/tests/test_instrument.py
+++ b/src/guarneri/tests/test_instrument.py
@@ -108,7 +108,6 @@ def test_make_unknown_class(instrument):
     """Check that unresolvable device classes only raise a warning."""
     instrument.device_classes = {}
     cfg = instrument.parse_config(toml_file)
-    print(cfg)
     assert len(cfg) > 0
     dfn = cfg[0]
     assert dfn["device_class"] == "async_device"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

In order for Guarneri to work with our beamline's Haven package, I needed a few tweaks. This PR merges those tweaks.

I can split them out into multiple PRs if necessary, but they are somewhat related.

## Description
<!--- Describe your changes in detail -->

### Unknown device classes

Previously, if there was a ``device_class`` that was not available, this would raise a KeyError. There could be 2 reasons for this:

1. Some non-device section is included in the configuration file.
2. There is a mistake, either in the configuration file or the classes provided the ``Instrument``

In the case of (1), this should not prevent us from loading the other instruments. In the case of (2), we want to know about this mistake up-front before we try to use a device that wasn't created.

The compromise included her is to emit a warning. If the client code knows that this is because of (1), it can use the *ignored_classes* argument described below.

### *ignored_classes* parameter

It may be the case that only a sub-set of the known device classes should be loaded at a given time. An example from *haven* is the function *load_motors* which creates devices for every motor in a VME crate, e.g. ``load_motors(prefix="255idcVME:", num_motors=64)`` will load 255idcVME:m1...m64. However, many of these motors are already used by other devices and so shouldn't be duplicated. To do this, it takes two steps:

1. Load all device_classes except for ``load_motors()`` factory.
2. Load the device_class ``load_motors()`` which skips existing motors in the registry with the same *source* attribute.

Now, with this change we can use the following structure:

```python
instrument = Instrument({
    "monochromator": Monochromator,
    ...,
    "motors": load_motors,
})
# Step (1)
instrument.load(ignore_classes=['motors'])
# Step (2)
ignored_classes = [d for d in instrument.device_classes.key() if d != "motors"]
instrument.load(ignored_classes=ignore_classes)
# Finally, connect to all the devices
await instrument.connect()
```

### Re-registering devices after ``conect()``

Some of our *haven* devices change their device name after connecting.

For example, an ion chamber has ``name=""` when first created, but during ``IonChamber.connect()`` it will check the scaler channel's .DESC field and update its name with this value. Since the device is first registered during ``load()``, it needs to be re-registered after being successfully connected to be available in the ``Instrument.devices`` registry.