### PR TITLE
Remove buried File I/O

### DIFF
--- a/src/guarneri/tests/test_instrument.py
+++ b/src/guarneri/tests/test_instrument.py
@@ -96,9 +96,14 @@ def test_validate_wrong_types(instrument):
         instrument.validate_params(defn, AsyncDevice)
 
 
-@pytest.mark.parametrize("cfg_file", [toml_file, str(toml_file)])
-def test_parse_config(cfg_file, instrument):
-    cfg = instrument.parse_config(cfg_file)
+@pytest.fixture()
+def config_io():
+    with open(toml_file, mode="rt") as fd:
+        yield fd
+
+
+def test_parse_config(config_io, instrument):
+    cfg = instrument.parse_config(config_io, config_format="toml")
     assert len(cfg) > 0
     dfn = cfg[0]
     assert dfn["device_class"] == "async_device"


### PR DESCRIPTION
``Instrument.load()`` currently accepts a string or Path() object. This PR allows it to accept an open file object as well.

## Description

Previously, the File I/O was buried in the individual config file methods. This limits the possible sources of configuration to files on disk with known encodings.

With this PR, the File I/O is done close to the top of the call stack when using ``Instrument.load()``. This also means that ``load()`` can accept an already open FileIO object, allowing for more flexibility.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes: https://github.com/spc-group/guarneri/issues/14

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests pass. I'll also test this in the Haven package before merging.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

Docstrings have been updated, and type hints added.

<!--
## Screenshots (if appropriate):
-->
