### PR TITLE
raise exception for duplicate keys in a YAML file

### DIFF
--- a/src/guarneri/exceptions.py
+++ b/src/guarneri/exceptions.py
@@ -20,3 +20,9 @@ class InvalidComponentLabel(TypeError):
     """Registry looked for a component, but the label provided is not vlaid."""
 
     ...
+
+
+class DuplicateYamlKey(ValueError):
+    """A YAML configuration file contains duplicate keys."""
+
+    ...

--- a/src/guarneri/instrument.py
+++ b/src/guarneri/instrument.py
@@ -15,7 +15,7 @@ import yaml
 from ophyd.sim import make_fake_device
 from ophyd_async.core import DEFAULT_TIMEOUT, NotConnectedError
 
-from .exceptions import InvalidConfiguration
+from .exceptions import DuplicateYamlKey, InvalidConfiguration
 from .helpers import AsyncDevice, Device, Loader, ThreadedDevice, dynamic_import
 from .registry import Registry
 
@@ -26,6 +26,72 @@ instrument = None
 
 
 K = TypeVar("K")
+
+
+def _yaml_safe_load_no_duplicates(stream: IO[str], file_name: str) -> Any:
+    """Load YAML from *stream*, raising on duplicate mapping keys.
+
+    Uses a custom :class:`yaml.SafeLoader` subclass that checks every
+    mapping node for duplicate keys.  When a duplicate is found a
+    :class:`DuplicateYamlKey` exception is raised whose message
+    includes *file_name* and the line numbers of both the first
+    occurrence and the duplicate.
+
+    Parameters
+    ==========
+    stream
+      Readable text stream containing YAML.
+    file_name
+      Name shown in the error message (typically the file path).
+
+    Raises
+    ======
+    DuplicateYamlKey
+      If any mapping contains a duplicate key.
+    """
+
+    class _NoDuplicateKeysLoader(yaml.SafeLoader):
+        """SafeLoader subclass that forbids duplicate mapping keys."""
+
+        pass
+
+    def _check_duplicate_keys(loader, node):  # type: ignore[no-untyped-def]
+        """Construct a mapping, raising on duplicate keys."""
+        seen: dict[Any, yaml.Node] = {}
+        for key_node, _value_node in node.value:
+            key = loader.construct_object(key_node)
+            if key in seen:
+                first_node = seen[key]
+                # YAML lines are 0-indexed in marks; report 1-indexed.
+                first_line = first_node.start_mark.line + 1
+                dup_line = key_node.start_mark.line + 1
+                raise DuplicateYamlKey(
+                    f"Duplicate YAML key {key!r} in file {file_name!r}:"
+                    f" first defined on line {first_line},"
+                    f" redefined on line {dup_line}."
+                )
+            seen[key] = key_node
+        return loader.construct_pairs(node)
+
+    _NoDuplicateKeysLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        _check_duplicate_keys,
+    )
+
+    # yaml.load returns ordered pairs from _check_duplicate_keys for
+    # each mapping, but we need a dict.  Walk the structure and convert.
+    raw = yaml.load(stream, Loader=_NoDuplicateKeysLoader)  # noqa: S506
+    return _pairs_to_dicts(raw)
+
+
+def _pairs_to_dicts(obj: Any) -> Any:
+    """Recursively convert lists-of-pairs (from construct_pairs) to dicts."""
+    if isinstance(obj, list):
+        # A list of 2-tuples is a mapping produced by construct_pairs.
+        if obj and all(isinstance(item, tuple) and len(item) == 2 for item in obj):
+            return {k: _pairs_to_dicts(v) for k, v in obj}
+        return [_pairs_to_dicts(item) for item in obj]
+    return obj
 
 
 class Instrument:
@@ -132,6 +198,11 @@ class Instrument:
         Produce device definitions from a YAML file.
 
         See ``parse_config()`` for details.
+
+        Raises
+        ======
+        DuplicateYamlKey
+          If any mapping in the YAML file contains duplicate keys.
         """
 
         def yaml_parser(creator, specs):
@@ -145,8 +216,10 @@ class Instrument:
             ]
             return entries
 
+        file_name = getattr(config_file, "name", "<unknown>")
+
         try:
-            config_data = yaml.safe_load(config_file)
+            config_data = _yaml_safe_load_no_duplicates(config_file, file_name)
         except yaml.YAMLError as e:
             log.error("YAML parsing error: %s", str(e))
             raise

--- a/src/guarneri/tests/test_instrument.py
+++ b/src/guarneri/tests/test_instrument.py
@@ -242,12 +242,7 @@ class TestDuplicateYamlKeys:
 
     def test_error_message_contains_file_name(self, instrument, tmp_path):
         """The error message must reference the file name."""
-        yaml_content = (
-            "ophyd.Signal:\n"
-            "- name: sig1\n"
-            "ophyd.Signal:\n"
-            "- name: sig2\n"
-        )
+        yaml_content = "ophyd.Signal:\n- name: sig1\nophyd.Signal:\n- name: sig2\n"
         yaml_path = tmp_path / "dup_filename.yaml"
         yaml_path.write_text(yaml_content)
 
@@ -259,11 +254,11 @@ class TestDuplicateYamlKeys:
     def test_error_message_contains_line_numbers(self, instrument, tmp_path):
         """The error message must include both line numbers."""
         yaml_content = (
-            "ophyd.Signal:\n"       # line 1
-            "- name: sig1\n"        # line 2
-            "  value: 1.0\n"        # line 3
-            "ophyd.Signal:\n"       # line 4
-            "- name: sig2\n"        # line 5
+            "ophyd.Signal:\n"  # line 1
+            "- name: sig1\n"  # line 2
+            "  value: 1.0\n"  # line 3
+            "ophyd.Signal:\n"  # line 4
+            "- name: sig2\n"  # line 5
         )
         yaml_path = tmp_path / "dup_lines.yaml"
         yaml_path.write_text(yaml_content)
@@ -278,12 +273,7 @@ class TestDuplicateYamlKeys:
 
     def test_error_message_contains_duplicate_key_name(self, instrument, tmp_path):
         """The error message must include the actual duplicated key."""
-        yaml_content = (
-            "ophyd.EpicsMotor:\n"
-            "- name: m1\n"
-            "ophyd.EpicsMotor:\n"
-            "- name: m2\n"
-        )
+        yaml_content = "ophyd.EpicsMotor:\n- name: m1\nophyd.EpicsMotor:\n- name: m2\n"
         yaml_path = tmp_path / "dup_key_name.yaml"
         yaml_path.write_text(yaml_content)
 
@@ -294,11 +284,7 @@ class TestDuplicateYamlKeys:
 
     def test_nested_duplicate_key(self, instrument, tmp_path):
         """Duplicate keys inside a nested mapping are also detected."""
-        yaml_content = (
-            "ophyd.Signal:\n"
-            "- name: sig1\n"
-            "  name: sig1_dup\n"
-        )
+        yaml_content = "ophyd.Signal:\n- name: sig1\n  name: sig1_dup\n"
         yaml_path = tmp_path / "dup_nested.yaml"
         yaml_path.write_text(yaml_content)
 
@@ -325,12 +311,7 @@ class TestDuplicateYamlKeys:
 
     def test_duplicate_key_via_load(self, tmp_path):
         """Duplicate keys are caught when going through the load() path."""
-        yaml_content = (
-            "ophyd.Signal:\n"
-            "- name: sig1\n"
-            "ophyd.Signal:\n"
-            "- name: sig2\n"
-        )
+        yaml_content = "ophyd.Signal:\n- name: sig1\nophyd.Signal:\n- name: sig2\n"
         yaml_path = tmp_path / "dup_load.yaml"
         yaml_path.write_text(yaml_content)
 

--- a/src/guarneri/tests/test_instrument.py
+++ b/src/guarneri/tests/test_instrument.py
@@ -215,3 +215,125 @@ def test_load(monkeypatch):
     # Check that the right methods were called
     instrument.parse_toml_file.assert_called_once()
     instrument.make_devices.assert_called_once()
+
+
+# --- Tests for duplicate YAML key detection (issue #33) ---
+
+
+class TestDuplicateYamlKeys:
+    """Duplicate keys in YAML files must raise DuplicateYamlKey."""
+
+    def test_top_level_duplicate_key(self, instrument, tmp_path):
+        """Top-level duplicate keys are detected with file, lines, and key."""
+        yaml_content = (
+            "ophyd.Signal:\n"
+            "- name: sig1\n"
+            "  value: 1.0\n"
+            "ophyd.Signal:\n"
+            "- name: sig2\n"
+            "  value: 2.0\n"
+        )
+        yaml_path = tmp_path / "dup_top.yaml"
+        yaml_path.write_text(yaml_content)
+
+        with open(yaml_path, "rt") as fd:
+            with pytest.raises(exceptions.DuplicateYamlKey, match="ophyd.Signal"):
+                instrument.parse_yaml_file(fd)
+
+    def test_error_message_contains_file_name(self, instrument, tmp_path):
+        """The error message must reference the file name."""
+        yaml_content = (
+            "ophyd.Signal:\n"
+            "- name: sig1\n"
+            "ophyd.Signal:\n"
+            "- name: sig2\n"
+        )
+        yaml_path = tmp_path / "dup_filename.yaml"
+        yaml_path.write_text(yaml_content)
+
+        with open(yaml_path, "rt") as fd:
+            with pytest.raises(exceptions.DuplicateYamlKey) as exc_info:
+                instrument.parse_yaml_file(fd)
+        assert str(yaml_path) in str(exc_info.value)
+
+    def test_error_message_contains_line_numbers(self, instrument, tmp_path):
+        """The error message must include both line numbers."""
+        yaml_content = (
+            "ophyd.Signal:\n"       # line 1
+            "- name: sig1\n"        # line 2
+            "  value: 1.0\n"        # line 3
+            "ophyd.Signal:\n"       # line 4
+            "- name: sig2\n"        # line 5
+        )
+        yaml_path = tmp_path / "dup_lines.yaml"
+        yaml_path.write_text(yaml_content)
+
+        with open(yaml_path, "rt") as fd:
+            with pytest.raises(exceptions.DuplicateYamlKey) as exc_info:
+                instrument.parse_yaml_file(fd)
+        msg = str(exc_info.value)
+        # First occurrence on line 1, duplicate on line 4
+        assert "line 1" in msg
+        assert "line 4" in msg
+
+    def test_error_message_contains_duplicate_key_name(self, instrument, tmp_path):
+        """The error message must include the actual duplicated key."""
+        yaml_content = (
+            "ophyd.EpicsMotor:\n"
+            "- name: m1\n"
+            "ophyd.EpicsMotor:\n"
+            "- name: m2\n"
+        )
+        yaml_path = tmp_path / "dup_key_name.yaml"
+        yaml_path.write_text(yaml_content)
+
+        with open(yaml_path, "rt") as fd:
+            with pytest.raises(exceptions.DuplicateYamlKey) as exc_info:
+                instrument.parse_yaml_file(fd)
+        assert "ophyd.EpicsMotor" in str(exc_info.value)
+
+    def test_nested_duplicate_key(self, instrument, tmp_path):
+        """Duplicate keys inside a nested mapping are also detected."""
+        yaml_content = (
+            "ophyd.Signal:\n"
+            "- name: sig1\n"
+            "  name: sig1_dup\n"
+        )
+        yaml_path = tmp_path / "dup_nested.yaml"
+        yaml_path.write_text(yaml_content)
+
+        with open(yaml_path, "rt") as fd:
+            with pytest.raises(exceptions.DuplicateYamlKey, match="name"):
+                instrument.parse_yaml_file(fd)
+
+    def test_no_duplicate_keys_succeeds(self, instrument, tmp_path):
+        """A valid YAML file without duplicates parses normally."""
+        yaml_content = (
+            "ophyd.Signal:\n"
+            "- name: sig1\n"
+            "  value: 1.0\n"
+            "ophyd.EpicsMotor:\n"
+            "- name: m1\n"
+            "  prefix: IOC:m1\n"
+        )
+        yaml_path = tmp_path / "no_dup.yaml"
+        yaml_path.write_text(yaml_content)
+
+        with open(yaml_path, "rt") as fd:
+            cfg = instrument.parse_yaml_file(fd)
+        assert len(cfg) == 2
+
+    def test_duplicate_key_via_load(self, tmp_path):
+        """Duplicate keys are caught when going through the load() path."""
+        yaml_content = (
+            "ophyd.Signal:\n"
+            "- name: sig1\n"
+            "ophyd.Signal:\n"
+            "- name: sig2\n"
+        )
+        yaml_path = tmp_path / "dup_load.yaml"
+        yaml_path.write_text(yaml_content)
+
+        inst = Instrument({})
+        with pytest.raises(exceptions.DuplicateYamlKey, match="ophyd.Signal"):
+            inst.load(yaml_path)


### PR DESCRIPTION
- closes #33

Raise exception instead of silently ignoring previous keys (default behavior for PyYAML).