### PR TITLE
Allow instrument.load() to be called with a mapping.

### DIFF
--- a/src/guarneri/iconfig_example.toml
+++ b/src/guarneri/iconfig_example.toml
@@ -1,9 +1,3 @@
-[beamline]
-name = "APS Beamline (sector unknown)"
-# Whether to connect to hardware (true) or use mocked signals (false)
-hardware_is_present = false
-
-
 [[ async_device ]]
 scaler_prefix = "255idcVME:3820:"
 scaler_channel = 2

--- a/src/guarneri/instrument.py
+++ b/src/guarneri/instrument.py
@@ -26,7 +26,6 @@ instrument = None
 
 
 K = TypeVar("K")
-T = TypeVar("T")
 
 
 def _tables_to_definitions(

--- a/src/guarneri/instrument.py
+++ b/src/guarneri/instrument.py
@@ -26,6 +26,59 @@ instrument = None
 
 
 K = TypeVar("K")
+T = TypeVar("T")
+
+
+def _tables_to_definitions(
+    tables: Mapping[str, Sequence[Mapping]],
+) -> list[dict[str, Any]]:
+    """Convert tables to device definitions.
+
+    *tables* should match:
+
+    ```
+    {
+      "ophyd_async.epics.motor.Motor": [
+        {
+          "name": "mono_bragg",
+          "prefix": "255idcVME:m1",
+        }
+      ]
+    }
+    ```
+
+    then defitions will match:
+
+    ```
+    [
+      {
+        "device_class": "ophyd_async.epics.motor.Motor",
+        "args": (),
+        "kwargs": {"name": "mono_bragg", "prefix": "255idcVME:m1"},
+      },
+    ]
+    ```
+    """
+
+    def yaml_parser(creator, specs):
+        entries = [
+            {
+                "device_class": creator,
+                "args": (),  # ALL specs are kwargs!
+                "kwargs": table,
+            }
+            for table in specs
+        ]
+        return entries
+
+    devices = [
+        device
+        # parse the file using already loaded config data
+        for k, v in tables.items()
+        # each support type (class, factory, function, ...)
+        for device in yaml_parser(k, v)
+    ]
+    return devices
 
 
 class Instrument:
@@ -134,17 +187,6 @@ class Instrument:
         See ``parse_config()`` for details.
         """
 
-        def yaml_parser(creator, specs):
-            entries = [
-                {
-                    "device_class": creator,
-                    "args": (),  # ALL specs are kwargs!
-                    "kwargs": table,
-                }
-                for table in specs
-            ]
-            return entries
-
         try:
             config_data = yaml.safe_load(config_file)
         except yaml.YAMLError as e:
@@ -160,13 +202,7 @@ class Instrument:
             raise ValueError(f"Invalid device file format in {config_file}")
 
         try:
-            devices = [
-                device
-                # parse the file using already loaded config data
-                for k, v in config_data.items()
-                # each support type (class, factory, function, ...)
-                for device in yaml_parser(k, v)
-            ]
+            devices = _tables_to_definitions(config_data)
         except Exception as e:
             log.error(
                 "Error parsing device specifications in %s: %s", config_file, str(e)
@@ -181,22 +217,20 @@ class Instrument:
 
         """
         # Load the file from disk
-        cfg = tomlkit.load(config_file)
+        try:
+            config_data = tomlkit.load(config_file)
+        except tomlkit.exceptions.ParseError as e:
+            log.error("TOML parsing error: %s", str(e))
+            raise
         # Convert file contents to device definitions
-        device_defns = []
-        sections = {
-            key: val for key, val in cfg.items() if isinstance(val, tomlkit.items.AoT)
-        }
-        tables = [(cls, table) for cls, aot in sections.items() for table in aot]
-        device_defns = [
-            {
-                "device_class": class_name,
-                "args": (),
-                "kwargs": table,
-            }
-            for class_name, table in tables
-        ]
-        return device_defns
+        try:
+            devices = _tables_to_definitions(config_data)
+        except Exception as e:
+            log.error(
+                "Error parsing device specifications in %s: %s", config_file, str(e)
+            )
+            raise
+        return devices
 
     def make_devices(self, defns: Sequence[Mapping], fake: bool) -> list[Device]:
         """Create Device instances based on device definitions.
@@ -441,7 +475,7 @@ class Instrument:
 
     def load(
         self,
-        config_file: Path | str | IO,
+        config_file: Path | str | IO | Mapping,
         *,
         config_format: str | None = None,
         fake: bool = False,
@@ -473,8 +507,12 @@ class Instrument:
         old_ignored = self.ignored_classes
         # Decide which format to use
         # Parse device configuration files
-        with self.open_config_file(config_file, config_format) as (fd, fmt):
-            device_defns = self.parse_config(fd, config_format=fmt)
+        if isinstance(config_file, Mapping):
+            # It's already the definitions, no parsing needed
+            device_defns = _tables_to_definitions(config_file)
+        else:
+            with self.open_config_file(config_file, config_format) as (fd, fmt):
+                device_defns = self.parse_config(fd, config_format=fmt)
         # Temprary override of device classes
         if device_classes is not None:
             self.device_classes = device_classes

--- a/src/guarneri/instrument.py
+++ b/src/guarneri/instrument.py
@@ -488,8 +488,9 @@ class Instrument:
         Parameters
         ==========
         config_file
-          A file path that will be loaded. Can be either a path to a
-          file, or the open file object itself.
+          A file path that will be loaded. Can be a path to a file,
+          the open file object itself, or a mapping containing the
+          contents that would be parsed from such a file.
         config_format
           Which kind of config file is in use. If ``None``, the format
           will be interpreted from the file path.
@@ -500,6 +501,42 @@ class Instrument:
           A temporary set of device classes to use for this call
           only. Overrides any device classes given during
           initalization.
+
+        The *config_file* argument can be any one of the following:
+
+        A pathlib.Path object
+        : This path should point to the file to be loaded, in one of
+        the supported formats (e.g. YAML or TOML).
+
+        A string
+        : Similar to pathlib.Path.
+
+        An open File IO object.
+        : Similar to pathlib.Path, but already open for reading. Could
+        also be a StringIO object.
+
+        A Mapping object
+        : Dictionary-like object that mirrors what is parsed from a
+        TOML/YAML/etc file.
+
+        In all cases, the structure of the resulting parsed data should be:
+
+        ```python
+        {
+            "path.to.device.class": [
+                {
+                    "name": "deviceA",
+                    "prefix": "255idcVME:myDevice",
+                    ...  # Other device parameters here
+                },
+                {
+                    "name": "deviceB",
+                    "prefix": "255idcVME:myDevice2",
+                    ...  # Other device parameters here
+                }
+            ]
+        }
+        ```
 
         """
         # Load the instrument from config files

--- a/src/guarneri/tests/test_instrument.py
+++ b/src/guarneri/tests/test_instrument.py
@@ -209,9 +209,29 @@ def test_load(monkeypatch):
     # Mock out the relevant methods to test
     monkeypatch.setattr(instrument, "parse_toml_file", MagicMock())
     monkeypatch.setattr(instrument, "make_devices", MagicMock(return_value=[]))
-    monkeypatch.setenv("HAVEN_CONFIG_FILES", str(toml_file), prepend=False)
     # Execute the loading step
     instrument.load(toml_file, fake=True)
     # Check that the right methods were called
     instrument.parse_toml_file.assert_called_once()
     instrument.make_devices.assert_called_once()
+
+
+def test_load_mapping(instrument):
+    """Check that we can pass a straight mapping, like the output from parsing a TOML file."""
+    instrument.load(
+        {
+            "async_device": [
+                {
+                    "scaler_prefix": "255idc:",
+                    "scaler_channel": 2,
+                    "preamp_prefix": "255idc:",
+                    "voltmeter_prefix": "255idc",
+                    "voltmeter_channel": 3,
+                    "counts_per_volt_second": 1e7,
+                    "name": "It",
+                    "auto_name": False,
+                },
+            ]
+        }
+    )
+    assert instrument.devices["It"].name == "It"


### PR DESCRIPTION
As a side-benefit, the loading of TOML files now mirrors YAML file loading better.

<!--- Provide a general summary of your changes in the Title above -->
## Description

Previously, `Instrument.load()` could be given a file path, a file path string, or an open IO object. This PR extends the choices to include a mapping with the same structure as would be read from one of the above.

I also removed some constraints that were in place because of haven's configuration structure. Haven recently changed it's configuration schema, so these constraints are no longer needed. As a consequence, the `yaml_parser()` has been renamed and is now used both when parsing YAML and TOML files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In some cases, the client may want to handle the file reading. One example is haven, which may read multiple files and pass the merged parameters to the instrument to load().

## How Has This Been Tested?

Added a unit-test that includes a call to `Instrument.load()` with *config_file* as a mapping.

## Where Has This Been Documented?

More details have been added to the docstring for `Instrument.load()`.

<!--
## Screenshots (if appropriate):
-->
